### PR TITLE
Allow node version 10 and higher. Fix #15.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 !.yarn/releases
 !.yarn/plugins
 .pnp.*
+.idea/

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "auto.js"
   ],
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=10"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Allow node version 10 and higher. Fix #15.